### PR TITLE
doc/Makefile.in: properly build and clean html doc.

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -117,11 +117,10 @@ html :
 	echo $$INTEGRIT_VERSION; \
 	sed "s/[@]INTEGRIT_VERSION[@]/$$INTEGRIT_VERSION/g" \
 	  integrit.texi.in > integrit.texi \
-	  && ~/opt/texinfo-4.2/bin/makeinfo --html --no-split integrit.texi
-# 	  && makeinfo --html integrit.texi
+ 	  && makeinfo --html --no-split integrit.texi
 
 clean	:
-	rm -f integrit.1 i-viewdb.1 i-ls.1 integrit.texi
+	rm -f integrit.1 i-viewdb.1 i-ls.1 integrit.texi integrit.html
 
 realclean : clean
 


### PR DESCRIPTION
The patch is from the Debian package, been used there since 2003 to fix https://bugs.debian.org/171902, if I am not mistaken.