### PR TITLE
allow tTdD in config rule checksets as documented.

### DIFF
--- a/README
+++ b/README
@@ -269,6 +269,8 @@ Here's a table of letters and the corresponding options:
         s	checksum
         i	inode
         p	permissions
+        t	file type
+        d	device type (if file is blk or chr special)
         l	number of links
         u	uid
         g	gid

--- a/examples/root.conf
+++ b/examples/root.conf
@@ -19,6 +19,8 @@ current=/root/databases/integrit-foohost.cdb.new
 # 	  s	checksum
 # 	  i	inode
 # 	  p	permissions
+#	  t	file type
+#	  d	device type (if file is blk or chr special)
 # 	  l	number of links
 # 	  u	uid
 # 	  g	gid

--- a/options.c
+++ b/options.c
@@ -312,7 +312,7 @@ inline static void do_rule(integrit_t *it, char *buf)
       buf[n_switches - 1]	 = '\0';
       --n_switches;
     }
-    if (strspn(buf, "SsIiPpLlUuGgZzAaMmCcRr") != n_switches)
+    if (strspn(buf, "SsIiPpTtDdLlUuGgZzAaMmCcRr") != n_switches)
       die(__FUNCTION__,
 	  "Error: unrecognized check switch in conf file rule for %s",
 	  namebuf);


### PR DESCRIPTION
The tTdD switches in config rule checksets are documented and implemented, so don't reject them in the options parser.

This was noticed by whollygoat and reported through
 http://bugs.debian.org/436360

This patch has been part of the Debian package since 2007.